### PR TITLE
bugfix: Fixes #17 centralized on message emitter and callback management

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -205,7 +205,7 @@ class DpsnClient extends EventEmitter {
 
   private topicCallbacks = new Map<
     string,
-    Array<(topic: string, message: any, packet?: mqtt.IPublishPacket) => void>
+    Set<(topic: string, message: any, packet?: mqtt.IPublishPacket) => void>
   >();
 
   constructor(
@@ -492,7 +492,7 @@ class DpsnClient extends EventEmitter {
           payload: Buffer,
           packet: mqtt.IPublishPacket
         ) => {
-          const cbs = this.topicCallbacks.get(receivedTopic) ?? [];
+          const cbs = this.topicCallbacks.get(receivedTopic) ?? new Set();
           let data: any;
           try {
             data = JSON.parse(payload.toString());
@@ -700,9 +700,9 @@ class DpsnClient extends EventEmitter {
       throw dpsnError;
     }
     if (!this.topicCallbacks.has(topic)) {
-      this.topicCallbacks.set(topic, []);
+      this.topicCallbacks.set(topic, new Set());
     }
-    this.topicCallbacks.get(topic)!.push(callback);
+    this.topicCallbacks.get(topic)!.add(callback);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,6 +203,11 @@ class DpsnClient extends EventEmitter {
   private contract?: ethers.Contract;
   private initializing: Promise<MqttClient> | null = null;
 
+  private topicCallbacks = new Map<
+    string,
+    Array<(topic: string, message: any, packet?: mqtt.IPublishPacket) => void>
+  >();
+
   constructor(
     dpsnUrl: string,
     privateKey: string,
@@ -269,13 +274,9 @@ class DpsnClient extends EventEmitter {
     // Check if the event is a DPSN event type
     if (
       typeof event === 'string' &&
-      [
-        'connect',
-        'subscription',
-        'publish',
-        'error',
-        'disconnect',
-      ].includes(event as string) &&
+      ['connect', 'subscription', 'publish', 'error', 'disconnect'].includes(
+        event as string
+      ) &&
       !event.includes('_success')
     ) {
       // Handle DPSN event types
@@ -302,6 +303,15 @@ class DpsnClient extends EventEmitter {
           return super.on(
             'disconnect_success',
             listener as (data: void) => void
+          );
+        case 'message':
+          return super.on(
+            'message',
+            listener as (
+              topic: string,
+              message: any,
+              packet?: mqtt.IPublishPacket
+            ) => void
           );
         default:
           return super.on(event, listener);
@@ -474,6 +484,27 @@ class DpsnClient extends EventEmitter {
         });
         this.emit('error', dpsnError);
       });
+
+      this.dpsnBroker!.on(
+        'message',
+        (
+          receivedTopic: string,
+          payload: Buffer,
+          packet: mqtt.IPublishPacket
+        ) => {
+          const cbs = this.topicCallbacks.get(receivedTopic) ?? [];
+          let data: any;
+          try {
+            data = JSON.parse(payload.toString());
+          } catch {
+            data = payload.toString();
+          }
+          for (const cb of cbs) {
+            cb(receivedTopic, data, packet);
+          }
+          super.emit('message', receivedTopic, data, packet);
+        }
+      );
 
       this.dpsnBroker!.on('close', () => {
         this.connected = false;
@@ -658,31 +689,6 @@ class DpsnClient extends EventEmitter {
           resolve();
         });
       });
-
-      // Set up message handler for this topic
-      this.dpsnBroker.on(
-        'message',
-        (
-          receivedTopic: string,
-          message: Buffer,
-          packet: mqtt.IPublishPacket
-        ) => {
-          if (receivedTopic === topic) {
-            try {
-              const parsedMessage = JSON.parse(message.toString());
-
-              callback(receivedTopic, parsedMessage, packet);
-            } catch (error) {
-              console.warn(
-                `⚠️ Error parsing message from DPSN topic '${topic}':`,
-                error
-              );
-              // Call callback with raw message if JSON parsing fails
-              callback(receivedTopic, message.toString(), packet);
-            }
-          }
-        }
-      );
     } catch (error) {
       const dpsnError = new DPSNError({
         code: DPSN_ERROR_CODES.SUBSCRIBE_SETUP_ERROR,
@@ -693,6 +699,10 @@ class DpsnClient extends EventEmitter {
       });
       throw dpsnError;
     }
+    if (!this.topicCallbacks.has(topic)) {
+      this.topicCallbacks.set(topic, []);
+    }
+    this.topicCallbacks.get(topic)!.push(callback);
   }
 
   /**


### PR DESCRIPTION
### What change does this PR introduce?
- This pr moves the dpsnbroker.on('message',()) from subscribe method to global level, and manage the callbacks registered to fanout the subscribed messages

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?
- The current  lib version 1.0.9 gives warning of potential memory leak , due to a new on('message') event being registered per subscription.
- This could cause issues when using library at scale
- Now the library fixes #17 

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->