### PR TITLE
refactor: reverted callback processing from on message event handler

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -304,15 +304,6 @@ class DpsnClient extends EventEmitter {
             'disconnect_success',
             listener as (data: void) => void
           );
-        case 'message':
-          return super.on(
-            'message',
-            listener as (
-              topic: string,
-              message: any,
-              packet?: mqtt.IPublishPacket
-            ) => void
-          );
         default:
           return super.on(event, listener);
       }
@@ -500,7 +491,6 @@ class DpsnClient extends EventEmitter {
           }
           const callback = this.topicCallbacks.get(receivedTopic);
           if (callback) callback(receivedTopic, data, packet);
-          super.emit('message', receivedTopic, data, packet);
         }
       );
 


### PR DESCRIPTION
### What change does this PR introduce?
- This PR reverts back callback processing from message event handler .

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?
- To maintain compatibility with current sdk api structure .

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->
